### PR TITLE
feat(protocols): CRUD de protocolos sanitarios (S2-01)

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -58,12 +58,14 @@ const groupRoutes = require('./routes/group.routes');
 const animalRoutes = require('./routes/animal.routes');
 const weightRoutes = require('./routes/weight.routes');
 const eventRoutes = require('./routes/event.routes');
+const protocolRoutes = require('./routes/protocol.routes');
 app.use('/api/auth', authRoutes);
 app.use('/api/groups', authenticate, groupRoutes);
 app.use('/api/animals', authenticate, animalRoutes);
 app.use('/api/animals', authenticate, weightRoutes);
 app.use('/api/animals', authenticate, eventRoutes);
 app.use('/api/events', authenticate, eventRoutes);
+app.use('/api/protocols', authenticate, protocolRoutes);
 
 // Global error handler (must be last)
 app.use(errorHandler);

--- a/server/src/controllers/protocol.controller.js
+++ b/server/src/controllers/protocol.controller.js
@@ -1,0 +1,51 @@
+const protocolService = require('../services/protocol.service');
+
+const getAll = async (req, res, next) => {
+  try {
+    const protocols = await protocolService.getAll(req.user.id);
+    res.json({ protocols });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const getById = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    const protocol = await protocolService.getById(req.user.id, protocolId);
+    res.json({ protocol });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const create = async (req, res, next) => {
+  try {
+    const protocol = await protocolService.create(req.user.id, req.body);
+    res.status(201).json({ protocol });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const update = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    const protocol = await protocolService.update(req.user.id, protocolId, req.body);
+    res.json({ protocol });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const remove = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    await protocolService.remove(req.user.id, protocolId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getAll, getById, create, update, remove };

--- a/server/src/routes/protocol.routes.js
+++ b/server/src/routes/protocol.routes.js
@@ -1,0 +1,13 @@
+const { Router } = require('express');
+const { getAll, getById, create, update, remove } = require('../controllers/protocol.controller');
+const { authorize } = require('../middlewares/roles');
+
+const router = Router();
+
+router.get('/', authorize('ADMIN', 'COLLABORATOR'), getAll);
+router.get('/:id', authorize('ADMIN', 'COLLABORATOR'), getById);
+router.post('/', authorize('ADMIN'), create);
+router.put('/:id', authorize('ADMIN'), update);
+router.delete('/:id', authorize('ADMIN'), remove);
+
+module.exports = router;

--- a/server/src/services/protocol.service.js
+++ b/server/src/services/protocol.service.js
@@ -1,0 +1,202 @@
+const prisma = require('../utils/prisma');
+const { ApiError } = require('../utils/ApiError');
+
+const STEP_INCLUDE = {
+  eventType: { select: { id: true, name: true, category: true, severityScore: true } },
+};
+
+const PROTOCOL_INCLUDE = {
+  steps: {
+    include: STEP_INCLUDE,
+    orderBy: { sortOrder: 'asc' },
+  },
+};
+
+const verifyOwnership = async (protocolId, userId) => {
+  const protocol = await prisma.protocol.findFirst({
+    where: { id: protocolId, userId },
+  });
+  if (!protocol) {
+    throw new ApiError(404, 'Protocol not found');
+  }
+  return protocol;
+};
+
+const validateSteps = async (steps) => {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (!step.eventTypeId) {
+      throw new ApiError(400, `Step ${i}: eventTypeId is required`);
+    }
+    if (step.dayOffset === undefined || step.dayOffset === null) {
+      throw new ApiError(400, `Step ${i}: dayOffset is required`);
+    }
+    const dayOffset = parseInt(step.dayOffset, 10);
+    if (isNaN(dayOffset) || dayOffset < 0) {
+      throw new ApiError(400, `Step ${i}: dayOffset must be an integer >= 0`);
+    }
+    const eventType = await prisma.eventType.findUnique({
+      where: { id: parseInt(step.eventTypeId, 10) },
+    });
+    if (!eventType) {
+      throw new ApiError(400, `Step ${i}: invalid eventTypeId`);
+    }
+  }
+};
+
+const getAll = async (userId) => {
+  const protocols = await prisma.protocol.findMany({
+    where: { userId },
+    include: {
+      ...PROTOCOL_INCLUDE,
+      _count: {
+        select: {
+          assignments: { where: { status: 'ACTIVE' } },
+        },
+      },
+    },
+    orderBy: { name: 'asc' },
+  });
+
+  return protocols;
+};
+
+const getById = async (userId, protocolId) => {
+  const protocol = await prisma.protocol.findFirst({
+    where: { id: protocolId, userId },
+    include: {
+      ...PROTOCOL_INCLUDE,
+      assignments: {
+        include: {
+          animal: {
+            select: {
+              id: true,
+              name: true,
+              group: { select: { id: true, name: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!protocol) {
+    throw new ApiError(404, 'Protocol not found');
+  }
+
+  return protocol;
+};
+
+const create = async (userId, data) => {
+  if (!data.name || typeof data.name !== 'string' || data.name.trim().length === 0) {
+    throw new ApiError(400, 'name is required');
+  }
+  if (data.name.trim().length > 100) {
+    throw new ApiError(400, 'name must be at most 100 characters');
+  }
+
+  const stepsData = [];
+  if (data.steps && Array.isArray(data.steps) && data.steps.length > 0) {
+    await validateSteps(data.steps);
+    for (let i = 0; i < data.steps.length; i++) {
+      const s = data.steps[i];
+      stepsData.push({
+        eventTypeId: parseInt(s.eventTypeId, 10),
+        dayOffset: parseInt(s.dayOffset, 10),
+        product: s.product || null,
+        notes: s.notes || null,
+        sortOrder: i,
+      });
+    }
+  }
+
+  const protocol = await prisma.$transaction(async (tx) => {
+    const created = await tx.protocol.create({
+      data: {
+        name: data.name.trim(),
+        description: data.description?.trim() || null,
+        userId,
+        steps: { create: stepsData },
+      },
+      include: PROTOCOL_INCLUDE,
+    });
+    return created;
+  });
+
+  return protocol;
+};
+
+const update = async (userId, protocolId, data) => {
+  await verifyOwnership(protocolId, userId);
+
+  if (data.name !== undefined) {
+    if (typeof data.name !== 'string' || data.name.trim().length === 0) {
+      throw new ApiError(400, 'name cannot be empty');
+    }
+    if (data.name.trim().length > 100) {
+      throw new ApiError(400, 'name must be at most 100 characters');
+    }
+  }
+
+  const hasSteps = data.steps && Array.isArray(data.steps);
+  if (hasSteps) {
+    await validateSteps(data.steps);
+  }
+
+  const protocol = await prisma.$transaction(async (tx) => {
+    const updateData = {};
+    if (data.name !== undefined) {
+      updateData.name = data.name.trim();
+    }
+    if (data.description !== undefined) {
+      updateData.description = data.description?.trim() || null;
+    }
+
+    await tx.protocol.update({
+      where: { id: protocolId },
+      data: updateData,
+    });
+
+    if (hasSteps) {
+      await tx.protocolStep.deleteMany({ where: { protocolId } });
+      for (let i = 0; i < data.steps.length; i++) {
+        const s = data.steps[i];
+        await tx.protocolStep.create({
+          data: {
+            protocolId,
+            eventTypeId: parseInt(s.eventTypeId, 10),
+            dayOffset: parseInt(s.dayOffset, 10),
+            product: s.product || null,
+            notes: s.notes || null,
+            sortOrder: i,
+          },
+        });
+      }
+    }
+
+    return tx.protocol.findUnique({
+      where: { id: protocolId },
+      include: PROTOCOL_INCLUDE,
+    });
+  });
+
+  return protocol;
+};
+
+const remove = async (userId, protocolId) => {
+  await verifyOwnership(protocolId, userId);
+
+  const activeCount = await prisma.protocolAssignment.count({
+    where: { protocolId, status: 'ACTIVE' },
+  });
+  if (activeCount > 0) {
+    throw new ApiError(
+      400,
+      'Cannot delete protocol with active assignments. Cancel or complete them first'
+    );
+  }
+
+  await prisma.protocol.delete({ where: { id: protocolId } });
+};
+
+module.exports = { getAll, getById, create, update, remove };


### PR DESCRIPTION
## Summary
- GET/POST/PUT/DELETE /api/protocols con ownership del usuario
- POST/PUT soportan creación inline de steps con validación de eventType y sortOrder automático
- DELETE bloquea si el protocolo tiene asignaciones activas
- GET list incluye steps con eventType y conteo de asignaciones activas
- GET detail incluye asignaciones con animal y grupo

## Test plan
- [ ] Validar que las rutas requieren JWT
- [ ] Validar que solo ADMIN puede POST/PUT/DELETE
- [ ] Verificar creación con steps inline en transacción
- [ ] Verificar bloqueo de DELETE con asignaciones activas