### PR TITLE
feat(events): recálculo en cascada de fechas de protocolo (S2-04)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,8 @@
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.1",
         "multer": "^2.1.1",
-        "pg": "^8.20.0"
+        "pg": "^8.20.0",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -1643,6 +1644,13 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -7723,6 +7731,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {

--- a/server/package.json
+++ b/server/package.json
@@ -22,12 +22,17 @@
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.1",
     "multer": "^2.1.1",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "jest": {
     "testEnvironment": "node",
-    "setupFiles": ["./src/tests/setup.js"],
-    "testMatch": ["**/src/tests/**/*.test.js"]
+    "setupFiles": [
+      "./src/tests/setup.js"
+    ],
+    "testMatch": [
+      "**/src/tests/**/*.test.js"
+    ]
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -3,9 +3,14 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const morgan = require('morgan');
+const swaggerUi = require('swagger-ui-express');
+const swaggerDoc = require('./swagger.json');
 const { errorHandler } = require('./middlewares/errorHandler');
 
 const app = express();
+
+// API docs
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 
 // Security headers
 app.use(helmet());

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -64,11 +64,14 @@ const animalRoutes = require('./routes/animal.routes');
 const weightRoutes = require('./routes/weight.routes');
 const eventRoutes = require('./routes/event.routes');
 const protocolRoutes = require('./routes/protocol.routes');
+const assignmentRoutes = require('./routes/assignment.routes');
 app.use('/api/auth', authRoutes);
 app.use('/api/groups', authenticate, groupRoutes);
 app.use('/api/animals', authenticate, animalRoutes);
 app.use('/api/animals', authenticate, weightRoutes);
 app.use('/api/animals', authenticate, eventRoutes);
+app.use('/api/animals', authenticate, assignmentRoutes);
+app.use('/api/assignments', authenticate, assignmentRoutes);
 app.use('/api/events', authenticate, eventRoutes);
 app.use('/api/protocols', authenticate, protocolRoutes);
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -58,12 +58,14 @@ const groupRoutes = require('./routes/group.routes');
 const animalRoutes = require('./routes/animal.routes');
 const weightRoutes = require('./routes/weight.routes');
 const eventRoutes = require('./routes/event.routes');
+const protocolRoutes = require('./routes/protocol.routes');
 app.use('/api/auth', authRoutes);
 app.use('/api/groups', authenticate, groupRoutes);
 app.use('/api/animals', authenticate, animalRoutes);
 app.use('/api/animals', authenticate, weightRoutes);
 app.use('/api/animals', authenticate, eventRoutes);
 app.use('/api/events', authenticate, eventRoutes);
+app.use('/api/protocols', authenticate, protocolRoutes);
 
 // Global error handler (must be last)
 app.use(errorHandler);

--- a/server/src/controllers/assignment.controller.js
+++ b/server/src/controllers/assignment.controller.js
@@ -1,0 +1,33 @@
+const assignmentService = require('../services/assignment.service');
+
+const assignProtocol = async (req, res, next) => {
+  try {
+    const animalId = parseInt(req.params.id, 10);
+    const assignment = await assignmentService.assignProtocol(req.user.id, animalId, req.body);
+    res.status(201).json({ assignment });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const getAssignments = async (req, res, next) => {
+  try {
+    const animalId = parseInt(req.params.id, 10);
+    const assignments = await assignmentService.getAssignments(req.user.id, animalId);
+    res.json({ assignments });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const cancelAssignment = async (req, res, next) => {
+  try {
+    const assignmentId = parseInt(req.params.id, 10);
+    const assignment = await assignmentService.cancelAssignment(req.user.id, assignmentId);
+    res.json({ assignment });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { assignProtocol, getAssignments, cancelAssignment };

--- a/server/src/controllers/protocol.controller.js
+++ b/server/src/controllers/protocol.controller.js
@@ -1,0 +1,51 @@
+const protocolService = require('../services/protocol.service');
+
+const getAll = async (req, res, next) => {
+  try {
+    const protocols = await protocolService.getAll(req.user.id);
+    res.json({ protocols });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const getById = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    const protocol = await protocolService.getById(req.user.id, protocolId);
+    res.json({ protocol });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const create = async (req, res, next) => {
+  try {
+    const protocol = await protocolService.create(req.user.id, req.body);
+    res.status(201).json({ protocol });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const update = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    const protocol = await protocolService.update(req.user.id, protocolId, req.body);
+    res.json({ protocol });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const remove = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    await protocolService.remove(req.user.id, protocolId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getAll, getById, create, update, remove };

--- a/server/src/controllers/protocol.controller.js
+++ b/server/src/controllers/protocol.controller.js
@@ -48,4 +48,46 @@ const remove = async (req, res, next) => {
   }
 };
 
-module.exports = { getAll, getById, create, update, remove };
+const addStep = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    const step = await protocolService.addStep(req.user.id, protocolId, req.body);
+    res.status(201).json({ step });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const updateStep = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.protocolId, 10);
+    const stepId = parseInt(req.params.stepId, 10);
+    const step = await protocolService.updateStep(req.user.id, protocolId, stepId, req.body);
+    res.json({ step });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const removeStep = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.protocolId, 10);
+    const stepId = parseInt(req.params.stepId, 10);
+    await protocolService.removeStep(req.user.id, protocolId, stepId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+const reorderSteps = async (req, res, next) => {
+  try {
+    const protocolId = parseInt(req.params.id, 10);
+    const steps = await protocolService.reorderSteps(req.user.id, protocolId, req.body.stepIds);
+    res.json({ steps });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getAll, getById, create, update, remove, addStep, updateStep, removeStep, reorderSteps };

--- a/server/src/routes/assignment.routes.js
+++ b/server/src/routes/assignment.routes.js
@@ -1,0 +1,14 @@
+const { Router } = require('express');
+const { assignProtocol, getAssignments, cancelAssignment } = require('../controllers/assignment.controller');
+const { authorize } = require('../middlewares/roles');
+
+const router = Router({ mergeParams: true });
+
+// Nested under /api/animals/:id
+router.post('/:id/assign-protocol', authorize('ADMIN'), assignProtocol);
+router.get('/:id/assignments', authorize('ADMIN', 'COLLABORATOR'), getAssignments);
+
+// Direct under /api/assignments/:id
+router.patch('/:id/cancel', authorize('ADMIN'), cancelAssignment);
+
+module.exports = router;

--- a/server/src/routes/protocol.routes.js
+++ b/server/src/routes/protocol.routes.js
@@ -1,0 +1,13 @@
+const { Router } = require('express');
+const { getAll, getById, create, update, remove } = require('../controllers/protocol.controller');
+const { authorize } = require('../middlewares/roles');
+
+const router = Router();
+
+router.get('/', authorize('ADMIN', 'COLLABORATOR'), getAll);
+router.get('/:id', authorize('ADMIN', 'COLLABORATOR'), getById);
+router.post('/', authorize('ADMIN'), create);
+router.put('/:id', authorize('ADMIN'), update);
+router.delete('/:id', authorize('ADMIN'), remove);
+
+module.exports = router;

--- a/server/src/routes/protocol.routes.js
+++ b/server/src/routes/protocol.routes.js
@@ -1,5 +1,8 @@
 const { Router } = require('express');
-const { getAll, getById, create, update, remove } = require('../controllers/protocol.controller');
+const {
+  getAll, getById, create, update, remove,
+  addStep, updateStep, removeStep, reorderSteps,
+} = require('../controllers/protocol.controller');
 const { authorize } = require('../middlewares/roles');
 
 const router = Router();
@@ -9,5 +12,11 @@ router.get('/:id', authorize('ADMIN', 'COLLABORATOR'), getById);
 router.post('/', authorize('ADMIN'), create);
 router.put('/:id', authorize('ADMIN'), update);
 router.delete('/:id', authorize('ADMIN'), remove);
+
+// Steps
+router.post('/:id/steps', authorize('ADMIN'), addStep);
+router.put('/:id/steps/reorder', authorize('ADMIN'), reorderSteps);
+router.put('/:protocolId/steps/:stepId', authorize('ADMIN'), updateStep);
+router.delete('/:protocolId/steps/:stepId', authorize('ADMIN'), removeStep);
 
 module.exports = router;

--- a/server/src/services/assignment.service.js
+++ b/server/src/services/assignment.service.js
@@ -1,0 +1,179 @@
+const prisma = require('../utils/prisma');
+const { ApiError } = require('../utils/ApiError');
+
+const getUserGroupIds = async (userId) => {
+  const groups = await prisma.group.findMany({
+    where: { userId },
+    select: { id: true },
+  });
+  return groups.map((g) => g.id);
+};
+
+const verifyAnimalOwnership = async (animalId, userId) => {
+  const groupIds = await getUserGroupIds(userId);
+  const animal = await prisma.animal.findFirst({
+    where: { id: animalId, groupId: { in: groupIds } },
+  });
+  if (!animal) {
+    throw new ApiError(404, 'Animal not found');
+  }
+  return animal;
+};
+
+const addDays = (date, days) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+const assignProtocol = async (userId, animalId, data) => {
+  await verifyAnimalOwnership(animalId, userId);
+
+  if (!data.protocolId) {
+    throw new ApiError(400, 'protocolId is required');
+  }
+  if (!data.startDate) {
+    throw new ApiError(400, 'startDate is required');
+  }
+
+  const protocolId = parseInt(data.protocolId, 10);
+  const startDate = new Date(data.startDate);
+  if (isNaN(startDate.getTime())) {
+    throw new ApiError(400, 'startDate must be a valid date');
+  }
+
+  const protocol = await prisma.protocol.findFirst({
+    where: { id: protocolId, userId },
+    include: {
+      steps: {
+        orderBy: { sortOrder: 'asc' },
+        include: {
+          eventType: { select: { id: true, name: true, category: true } },
+        },
+      },
+    },
+  });
+  if (!protocol) {
+    throw new ApiError(404, 'Protocol not found');
+  }
+
+  const existingActive = await prisma.protocolAssignment.findFirst({
+    where: { animalId, protocolId, status: 'ACTIVE' },
+  });
+  if (existingActive) {
+    throw new ApiError(400, 'This protocol is already active for this animal');
+  }
+
+  const now = new Date();
+
+  const result = await prisma.$transaction(async (tx) => {
+    const assignment = await tx.protocolAssignment.create({
+      data: {
+        animalId,
+        protocolId,
+        startDate,
+        status: 'ACTIVE',
+      },
+    });
+
+    const events = [];
+    for (const step of protocol.steps) {
+      const scheduledDate = addDays(startDate, step.dayOffset);
+      const status = scheduledDate < now ? 'OVERDUE' : 'PENDING';
+
+      const event = await tx.healthEvent.create({
+        data: {
+          animalId,
+          eventTypeId: step.eventTypeId,
+          scheduledDate,
+          product: step.product,
+          notes: step.notes,
+          status,
+          protocolAssignmentId: assignment.id,
+          completedDate: null,
+          frequencyDays: null,
+        },
+        include: {
+          eventType: { select: { id: true, name: true, category: true, severityScore: true } },
+        },
+      });
+      events.push(event);
+    }
+
+    return {
+      ...assignment,
+      protocol: { name: protocol.name },
+      healthEvents: events,
+    };
+  });
+
+  return result;
+};
+
+const getAssignments = async (userId, animalId) => {
+  await verifyAnimalOwnership(animalId, userId);
+
+  const assignments = await prisma.protocolAssignment.findMany({
+    where: { animalId },
+    include: {
+      protocol: { select: { id: true, name: true, description: true } },
+      healthEvents: { select: { status: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return assignments.map((a) => {
+    const counts = { pending: 0, completed: 0, overdue: 0, skipped: 0 };
+    for (const e of a.healthEvents) {
+      const key = e.status.toLowerCase();
+      if (counts[key] !== undefined) {
+        counts[key]++;
+      }
+    }
+    const { healthEvents, ...rest } = a;
+    return { ...rest, eventCounts: counts };
+  });
+};
+
+const cancelAssignment = async (userId, assignmentId) => {
+  const assignment = await prisma.protocolAssignment.findFirst({
+    where: { id: assignmentId },
+    include: { animal: { select: { groupId: true } } },
+  });
+  if (!assignment) {
+    throw new ApiError(404, 'Assignment not found');
+  }
+
+  const groupIds = await getUserGroupIds(userId);
+  if (!groupIds.includes(assignment.animal.groupId)) {
+    throw new ApiError(404, 'Assignment not found');
+  }
+
+  if (assignment.status !== 'ACTIVE') {
+    throw new ApiError(400, 'Assignment is not active');
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const updated = await tx.protocolAssignment.update({
+      where: { id: assignmentId },
+      data: { status: 'CANCELLED' },
+      include: {
+        protocol: { select: { id: true, name: true } },
+      },
+    });
+
+    await tx.healthEvent.updateMany({
+      where: {
+        protocolAssignmentId: assignmentId,
+        status: 'PENDING',
+      },
+      data: { status: 'SKIPPED' },
+    });
+
+    return updated;
+  });
+
+  return result;
+};
+
+module.exports = { assignProtocol, getAssignments, cancelAssignment };

--- a/server/src/services/event.service.js
+++ b/server/src/services/event.service.js
@@ -1,5 +1,6 @@
 const prisma = require('../utils/prisma');
 const { ApiError } = require('../utils/ApiError');
+const { recalculateCascade } = require('./recalculation.service');
 
 const getUserGroupIds = async (userId) => {
   const groups = await prisma.group.findMany({
@@ -268,7 +269,9 @@ const complete = async (userId, eventId, data) => {
     });
   }
 
-  return { event, nextEvent };
+  const recalculation = await recalculateCascade(existing, completedDate);
+
+  return { event, nextEvent, recalculation };
 };
 
 const remove = async (userId, eventId) => {

--- a/server/src/services/protocol.service.js
+++ b/server/src/services/protocol.service.js
@@ -1,0 +1,202 @@
+const prisma = require('../utils/prisma');
+const { ApiError } = require('../utils/ApiError');
+
+const STEP_INCLUDE = {
+  eventType: { select: { id: true, name: true, category: true, severityScore: true } },
+};
+
+const PROTOCOL_INCLUDE = {
+  steps: {
+    include: STEP_INCLUDE,
+    orderBy: { sortOrder: 'asc' },
+  },
+};
+
+const verifyOwnership = async (protocolId, userId) => {
+  const protocol = await prisma.protocol.findFirst({
+    where: { id: protocolId, userId },
+  });
+  if (!protocol) {
+    throw new ApiError(404, 'Protocol not found');
+  }
+  return protocol;
+};
+
+const validateSteps = async (steps) => {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (!step.eventTypeId) {
+      throw new ApiError(400, `Step ${i}: eventTypeId is required`);
+    }
+    if (step.dayOffset === undefined || step.dayOffset === null) {
+      throw new ApiError(400, `Step ${i}: dayOffset is required`);
+    }
+    const dayOffset = parseInt(step.dayOffset, 10);
+    if (isNaN(dayOffset) || dayOffset < 0) {
+      throw new ApiError(400, `Step ${i}: dayOffset must be an integer >= 0`);
+    }
+    const eventType = await prisma.eventType.findUnique({
+      where: { id: parseInt(step.eventTypeId, 10) },
+    });
+    if (!eventType) {
+      throw new ApiError(400, `Step ${i}: invalid eventTypeId`);
+    }
+  }
+};
+
+const getAll = async (userId) => {
+  const protocols = await prisma.protocol.findMany({
+    where: { userId },
+    include: {
+      ...PROTOCOL_INCLUDE,
+      _count: {
+        select: {
+          assignments: { where: { status: 'ACTIVE' } },
+        },
+      },
+    },
+    orderBy: { name: 'asc' },
+  });
+
+  return protocols;
+};
+
+const getById = async (userId, protocolId) => {
+  const protocol = await prisma.protocol.findFirst({
+    where: { id: protocolId, userId },
+    include: {
+      ...PROTOCOL_INCLUDE,
+      assignments: {
+        include: {
+          animal: {
+            select: {
+              id: true,
+              name: true,
+              group: { select: { id: true, name: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!protocol) {
+    throw new ApiError(404, 'Protocol not found');
+  }
+
+  return protocol;
+};
+
+const create = async (userId, data) => {
+  if (!data.name || typeof data.name !== 'string' || data.name.trim().length === 0) {
+    throw new ApiError(400, 'name is required');
+  }
+  if (data.name.trim().length > 100) {
+    throw new ApiError(400, 'name must be at most 100 characters');
+  }
+
+  const stepsData = [];
+  if (data.steps && Array.isArray(data.steps) && data.steps.length > 0) {
+    await validateSteps(data.steps);
+    for (let i = 0; i < data.steps.length; i++) {
+      const s = data.steps[i];
+      stepsData.push({
+        eventTypeId: parseInt(s.eventTypeId, 10),
+        dayOffset: parseInt(s.dayOffset, 10),
+        product: s.product || null,
+        notes: s.notes || null,
+        sortOrder: i,
+      });
+    }
+  }
+
+  const protocol = await prisma.$transaction(async (tx) => {
+    const created = await tx.protocol.create({
+      data: {
+        name: data.name.trim(),
+        description: data.description?.trim() || null,
+        userId,
+        steps: { create: stepsData },
+      },
+      include: PROTOCOL_INCLUDE,
+    });
+    return created;
+  });
+
+  return protocol;
+};
+
+const update = async (userId, protocolId, data) => {
+  await verifyOwnership(protocolId, userId);
+
+  if (data.name !== undefined) {
+    if (typeof data.name !== 'string' || data.name.trim().length === 0) {
+      throw new ApiError(400, 'name cannot be empty');
+    }
+    if (data.name.trim().length > 100) {
+      throw new ApiError(400, 'name must be at most 100 characters');
+    }
+  }
+
+  const hasSteps = data.steps && Array.isArray(data.steps);
+  if (hasSteps) {
+    await validateSteps(data.steps);
+  }
+
+  const protocol = await prisma.$transaction(async (tx) => {
+    const updateData = {};
+    if (data.name !== undefined) {
+      updateData.name = data.name.trim();
+    }
+    if (data.description !== undefined) {
+      updateData.description = data.description?.trim() || null;
+    }
+
+    await tx.protocol.update({
+      where: { id: protocolId },
+      data: updateData,
+    });
+
+    if (hasSteps) {
+      await tx.protocolStep.deleteMany({ where: { protocolId } });
+      for (let i = 0; i < data.steps.length; i++) {
+        const s = data.steps[i];
+        await tx.protocolStep.create({
+          data: {
+            protocolId,
+            eventTypeId: parseInt(s.eventTypeId, 10),
+            dayOffset: parseInt(s.dayOffset, 10),
+            product: s.product || null,
+            notes: s.notes || null,
+            sortOrder: i,
+          },
+        });
+      }
+    }
+
+    return tx.protocol.findUnique({
+      where: { id: protocolId },
+      include: PROTOCOL_INCLUDE,
+    });
+  });
+
+  return protocol;
+};
+
+const remove = async (userId, protocolId) => {
+  await verifyOwnership(protocolId, userId);
+
+  const activeCount = await prisma.protocolAssignment.count({
+    where: { protocolId, status: 'ACTIVE' },
+  });
+  if (activeCount > 0) {
+    throw new ApiError(
+      400,
+      'Cannot delete protocol with active assignments. Cancel or complete them first'
+    );
+  }
+
+  await prisma.protocol.delete({ where: { id: protocolId } });
+};
+
+module.exports = { getAll, getById, create, update, remove };

--- a/server/src/services/protocol.service.js
+++ b/server/src/services/protocol.service.js
@@ -199,4 +199,158 @@ const remove = async (userId, protocolId) => {
   await prisma.protocol.delete({ where: { id: protocolId } });
 };
 
-module.exports = { getAll, getById, create, update, remove };
+const addStep = async (userId, protocolId, data) => {
+  await verifyOwnership(protocolId, userId);
+
+  if (!data.eventTypeId) {
+    throw new ApiError(400, 'eventTypeId is required');
+  }
+  if (data.dayOffset === undefined || data.dayOffset === null) {
+    throw new ApiError(400, 'dayOffset is required');
+  }
+  const dayOffset = parseInt(data.dayOffset, 10);
+  if (isNaN(dayOffset) || dayOffset < 0) {
+    throw new ApiError(400, 'dayOffset must be an integer >= 0');
+  }
+
+  const eventTypeId = parseInt(data.eventTypeId, 10);
+  const eventType = await prisma.eventType.findUnique({ where: { id: eventTypeId } });
+  if (!eventType) {
+    throw new ApiError(400, 'Invalid eventTypeId');
+  }
+
+  const maxStep = await prisma.protocolStep.findFirst({
+    where: { protocolId },
+    orderBy: { sortOrder: 'desc' },
+    select: { sortOrder: true },
+  });
+  const sortOrder = maxStep ? maxStep.sortOrder + 1 : 0;
+
+  const step = await prisma.protocolStep.create({
+    data: {
+      protocolId,
+      eventTypeId,
+      dayOffset,
+      product: data.product || null,
+      notes: data.notes || null,
+      sortOrder,
+    },
+    include: STEP_INCLUDE,
+  });
+
+  return step;
+};
+
+const verifyStepOwnership = async (protocolId, stepId, userId) => {
+  await verifyOwnership(protocolId, userId);
+  const step = await prisma.protocolStep.findFirst({
+    where: { id: stepId, protocolId },
+  });
+  if (!step) {
+    throw new ApiError(404, 'Step not found');
+  }
+  return step;
+};
+
+const updateStep = async (userId, protocolId, stepId, data) => {
+  await verifyStepOwnership(protocolId, stepId, userId);
+
+  const updateData = {};
+
+  if (data.eventTypeId !== undefined) {
+    const etId = parseInt(data.eventTypeId, 10);
+    const eventType = await prisma.eventType.findUnique({ where: { id: etId } });
+    if (!eventType) {
+      throw new ApiError(400, 'Invalid eventTypeId');
+    }
+    updateData.eventTypeId = etId;
+  }
+
+  if (data.dayOffset !== undefined) {
+    const d = parseInt(data.dayOffset, 10);
+    if (isNaN(d) || d < 0) {
+      throw new ApiError(400, 'dayOffset must be an integer >= 0');
+    }
+    updateData.dayOffset = d;
+  }
+
+  if (data.product !== undefined) {
+    updateData.product = data.product || null;
+  }
+  if (data.notes !== undefined) {
+    updateData.notes = data.notes || null;
+  }
+  if (data.sortOrder !== undefined) {
+    updateData.sortOrder = parseInt(data.sortOrder, 10);
+  }
+
+  const step = await prisma.protocolStep.update({
+    where: { id: stepId },
+    data: updateData,
+    include: STEP_INCLUDE,
+  });
+
+  return step;
+};
+
+const removeStep = async (userId, protocolId, stepId) => {
+  await verifyStepOwnership(protocolId, stepId, userId);
+
+  await prisma.protocolStep.delete({ where: { id: stepId } });
+
+  // Reorder remaining steps to remove gaps
+  const remaining = await prisma.protocolStep.findMany({
+    where: { protocolId },
+    orderBy: { sortOrder: 'asc' },
+    select: { id: true },
+  });
+
+  for (let i = 0; i < remaining.length; i++) {
+    await prisma.protocolStep.update({
+      where: { id: remaining[i].id },
+      data: { sortOrder: i },
+    });
+  }
+};
+
+const reorderSteps = async (userId, protocolId, stepIds) => {
+  await verifyOwnership(protocolId, userId);
+
+  if (!Array.isArray(stepIds) || stepIds.length === 0) {
+    throw new ApiError(400, 'stepIds must be a non-empty array');
+  }
+
+  const existingSteps = await prisma.protocolStep.findMany({
+    where: { protocolId },
+    select: { id: true },
+  });
+  const existingIds = new Set(existingSteps.map((s) => s.id));
+
+  for (const id of stepIds) {
+    if (!existingIds.has(id)) {
+      throw new ApiError(400, `Step ${id} does not belong to this protocol`);
+    }
+  }
+  if (stepIds.length !== existingIds.size) {
+    throw new ApiError(400, 'stepIds must include all steps of the protocol');
+  }
+
+  await prisma.$transaction(async (tx) => {
+    for (let i = 0; i < stepIds.length; i++) {
+      await tx.protocolStep.update({
+        where: { id: stepIds[i] },
+        data: { sortOrder: i },
+      });
+    }
+  });
+
+  const steps = await prisma.protocolStep.findMany({
+    where: { protocolId },
+    include: STEP_INCLUDE,
+    orderBy: { sortOrder: 'asc' },
+  });
+
+  return steps;
+};
+
+module.exports = { getAll, getById, create, update, remove, addStep, updateStep, removeStep, reorderSteps };

--- a/server/src/services/recalculation.service.js
+++ b/server/src/services/recalculation.service.js
@@ -1,0 +1,65 @@
+const prisma = require('../utils/prisma');
+
+const addDays = (date, days) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+const diffDays = (dateA, dateB) => {
+  const msPerDay = 86400000;
+  return Math.round((dateA.getTime() - dateB.getTime()) / msPerDay);
+};
+
+const recalculateCascade = async (completedEvent, completedDate) => {
+  if (!completedEvent.protocolAssignmentId) {
+    return null;
+  }
+
+  const delayDays = diffDays(completedDate, new Date(completedEvent.scheduledDate));
+  if (delayDays <= 0) {
+    return null;
+  }
+
+  const assignment = await prisma.protocolAssignment.findUnique({
+    where: { id: completedEvent.protocolAssignmentId },
+    select: { status: true },
+  });
+  if (!assignment || assignment.status === 'CANCELLED') {
+    return null;
+  }
+
+  const pendingEvents = await prisma.healthEvent.findMany({
+    where: {
+      protocolAssignmentId: completedEvent.protocolAssignmentId,
+      status: 'PENDING',
+      scheduledDate: { gt: completedEvent.scheduledDate },
+    },
+    orderBy: { scheduledDate: 'asc' },
+  });
+
+  if (pendingEvents.length === 0) {
+    return null;
+  }
+
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    for (const event of pendingEvents) {
+      const newDate = addDays(event.scheduledDate, delayDays);
+      const newStatus = newDate < now ? 'OVERDUE' : 'PENDING';
+
+      await tx.healthEvent.update({
+        where: { id: event.id },
+        data: {
+          scheduledDate: newDate,
+          status: newStatus,
+        },
+      });
+    }
+  });
+
+  return { delayDays, eventsUpdated: pendingEvents.length };
+};
+
+module.exports = { recalculateCascade };

--- a/server/src/swagger.json
+++ b/server/src/swagger.json
@@ -1,0 +1,649 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "PataPlan API",
+    "version": "0.1.0",
+    "description": "API for managing pet health, vaccination schedules, and veterinary records."
+  },
+  "servers": [
+    { "url": "http://localhost:3000", "description": "Development" }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": { "error": { "type": "string" } }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "email": { "type": "string" },
+          "role": { "type": "string", "enum": ["ADMIN", "COLLABORATOR"] },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "Animal": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "species": { "type": "string", "enum": ["DOG", "CAT", "OTHER"] },
+          "breed": { "type": "string", "nullable": true },
+          "sex": { "type": "string", "enum": ["MALE", "FEMALE", "UNKNOWN"] },
+          "dateOfBirth": { "type": "string", "format": "date", "nullable": true },
+          "microchip": { "type": "string", "nullable": true },
+          "photoUrl": { "type": "string", "nullable": true },
+          "notes": { "type": "string", "nullable": true },
+          "groupId": { "type": "integer" }
+        }
+      },
+      "Group": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "_count": {
+            "type": "object",
+            "properties": { "animals": { "type": "integer" } }
+          }
+        }
+      },
+      "WeightRecord": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "animalId": { "type": "integer" },
+          "valueKg": { "type": "number" },
+          "recordedAt": { "type": "string", "format": "date-time" },
+          "isAnomaly": { "type": "boolean" }
+        }
+      },
+      "HealthEvent": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "animalId": { "type": "integer" },
+          "eventTypeId": { "type": "integer" },
+          "scheduledDate": { "type": "string", "format": "date-time" },
+          "completedDate": { "type": "string", "format": "date-time", "nullable": true },
+          "product": { "type": "string", "nullable": true },
+          "vetName": { "type": "string", "nullable": true },
+          "notes": { "type": "string", "nullable": true },
+          "frequencyDays": { "type": "integer", "nullable": true },
+          "nextDueDate": { "type": "string", "format": "date-time", "nullable": true },
+          "status": { "type": "string", "enum": ["PENDING", "COMPLETED", "OVERDUE", "SKIPPED"] }
+        }
+      },
+      "Protocol": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "description": { "type": "string", "nullable": true },
+          "steps": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ProtocolStep" }
+          }
+        }
+      },
+      "ProtocolStep": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "protocolId": { "type": "integer" },
+          "eventTypeId": { "type": "integer" },
+          "dayOffset": { "type": "integer" },
+          "product": { "type": "string", "nullable": true },
+          "notes": { "type": "string", "nullable": true },
+          "sortOrder": { "type": "integer" }
+        }
+      }
+    }
+  },
+  "tags": [
+    { "name": "Health", "description": "Server health check" },
+    { "name": "Auth", "description": "Authentication and user management" },
+    { "name": "Groups", "description": "Animal groups management" },
+    { "name": "Animals", "description": "Animal profiles management" },
+    { "name": "Weights", "description": "Weight history and anomaly detection" },
+    { "name": "Health Events", "description": "Vaccination, deworming, and health events" },
+    { "name": "Protocols", "description": "Health protocol templates" },
+    { "name": "Protocol Steps", "description": "Individual step management within protocols" }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["Health"],
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Server is running",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "example": "ok" },
+                    "message": { "type": "string", "example": "PataPlan API" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/register": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Register a new user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name", "email", "password"],
+                "properties": {
+                  "name": { "type": "string", "example": "Jesús López", "minLength": 2, "maxLength": 100 },
+                  "email": { "type": "string", "format": "email", "example": "jesus@example.com" },
+                  "password": { "type": "string", "minLength": 8, "example": "securePassword123" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "User registered successfully" },
+          "400": { "description": "Validation error" },
+          "409": { "description": "Email already registered" }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Login and receive JWT token",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["email", "password"],
+                "properties": {
+                  "email": { "type": "string", "format": "email", "example": "admin@pataplan.com" },
+                  "password": { "type": "string", "example": "admin123" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Login successful, returns user and token" },
+          "400": { "description": "Validation error" },
+          "401": { "description": "Invalid credentials" }
+        }
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "tags": ["Auth"],
+        "summary": "Get authenticated user data",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "Current user data" },
+          "401": { "description": "Not authenticated" }
+        }
+      }
+    },
+    "/api/groups": {
+      "get": {
+        "tags": ["Groups"],
+        "summary": "List groups of the authenticated user",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "List of groups with animal count" },
+          "401": { "description": "Not authenticated" }
+        }
+      },
+      "post": {
+        "tags": ["Groups"],
+        "summary": "Create a new group",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "example": "Casa", "maxLength": 100 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Group created" },
+          "400": { "description": "Validation error" },
+          "409": { "description": "Group name already exists" }
+        }
+      }
+    },
+    "/api/groups/{id}": {
+      "put": {
+        "tags": ["Groups"],
+        "summary": "Update a group",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "example": "Refugio" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Group updated" },
+          "404": { "description": "Group not found" },
+          "409": { "description": "Group name already exists" }
+        }
+      },
+      "delete": {
+        "tags": ["Groups"],
+        "summary": "Delete a group (must have no animals)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "204": { "description": "Group deleted" },
+          "400": { "description": "Group has animals" },
+          "404": { "description": "Group not found" }
+        }
+      }
+    },
+    "/api/animals": {
+      "get": {
+        "tags": ["Animals"],
+        "summary": "List animals with optional filters",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "groupId", "in": "query", "schema": { "type": "integer" }, "description": "Filter by group" },
+          { "name": "species", "in": "query", "schema": { "type": "string", "enum": ["DOG", "CAT", "OTHER"] } },
+          { "name": "search", "in": "query", "schema": { "type": "string" }, "description": "Search by name" }
+        ],
+        "responses": {
+          "200": { "description": "List of animals with pending/overdue event counts" }
+        }
+      },
+      "post": {
+        "tags": ["Animals"],
+        "summary": "Create a new animal (supports photo upload)",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["name", "species", "sex", "groupId"],
+                "properties": {
+                  "name": { "type": "string", "example": "Rocky" },
+                  "species": { "type": "string", "enum": ["DOG", "CAT", "OTHER"] },
+                  "breed": { "type": "string" },
+                  "sex": { "type": "string", "enum": ["MALE", "FEMALE", "UNKNOWN"] },
+                  "dateOfBirth": { "type": "string", "format": "date" },
+                  "microchip": { "type": "string" },
+                  "groupId": { "type": "integer" },
+                  "notes": { "type": "string" },
+                  "photo": { "type": "string", "format": "binary" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Animal created" },
+          "400": { "description": "Validation error or invalid group" }
+        }
+      }
+    },
+    "/api/animals/{id}": {
+      "get": {
+        "tags": ["Animals"],
+        "summary": "Get animal detail with latest weight and event counts",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "200": { "description": "Animal detail" },
+          "404": { "description": "Animal not found" }
+        }
+      },
+      "put": {
+        "tags": ["Animals"],
+        "summary": "Update an animal",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "200": { "description": "Animal updated" },
+          "404": { "description": "Animal not found" }
+        }
+      },
+      "delete": {
+        "tags": ["Animals"],
+        "summary": "Delete an animal (cascade: events, weights, documents, expenses)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "204": { "description": "Animal deleted" },
+          "404": { "description": "Animal not found" }
+        }
+      }
+    },
+    "/api/animals/{id}/weights": {
+      "get": {
+        "tags": ["Weights"],
+        "summary": "Get weight history with trend data",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "200": { "description": "Weight records and trend (current, previous, change, average, min, max)" }
+        }
+      },
+      "post": {
+        "tags": ["Weights"],
+        "summary": "Add weight record (auto anomaly detection)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["valueKg", "recordedAt"],
+                "properties": {
+                  "valueKg": { "type": "number", "example": 29.5 },
+                  "recordedAt": { "type": "string", "format": "date", "example": "2026-04-10" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Weight recorded, includes anomalyDetected flag" }
+        }
+      }
+    },
+    "/api/animals/{id}/events": {
+      "get": {
+        "tags": ["Health Events"],
+        "summary": "List health events for an animal",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "status", "in": "query", "schema": { "type": "string", "enum": ["PENDING", "COMPLETED", "OVERDUE", "SKIPPED"] } },
+          { "name": "eventTypeId", "in": "query", "schema": { "type": "integer" } },
+          { "name": "from", "in": "query", "schema": { "type": "string", "format": "date" } },
+          { "name": "to", "in": "query", "schema": { "type": "string", "format": "date" } }
+        ],
+        "responses": {
+          "200": { "description": "List of health events with event type" }
+        }
+      },
+      "post": {
+        "tags": ["Health Events"],
+        "summary": "Create health event (auto-calculates status and nextDueDate)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["eventTypeId", "scheduledDate"],
+                "properties": {
+                  "eventTypeId": { "type": "integer" },
+                  "scheduledDate": { "type": "string", "format": "date" },
+                  "completedDate": { "type": "string", "format": "date" },
+                  "product": { "type": "string" },
+                  "vetName": { "type": "string" },
+                  "notes": { "type": "string" },
+                  "frequencyDays": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Event created" }
+        }
+      }
+    },
+    "/api/events/{id}": {
+      "put": {
+        "tags": ["Health Events"],
+        "summary": "Update a health event",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "200": { "description": "Event updated" },
+          "404": { "description": "Event not found" }
+        }
+      },
+      "delete": {
+        "tags": ["Health Events"],
+        "summary": "Delete a health event",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "204": { "description": "Event deleted" },
+          "404": { "description": "Event not found" }
+        }
+      }
+    },
+    "/api/events/{id}/complete": {
+      "patch": {
+        "tags": ["Health Events"],
+        "summary": "Mark event as completed (auto-generates next if has frequency)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "completedDate": { "type": "string", "format": "date" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Event completed, returns completed event and next event if generated" },
+          "400": { "description": "Event already completed" }
+        }
+      }
+    },
+    "/api/protocols": {
+      "get": {
+        "tags": ["Protocols"],
+        "summary": "List protocols of the authenticated user",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "List of protocols with steps and active assignment count" }
+        }
+      },
+      "post": {
+        "tags": ["Protocols"],
+        "summary": "Create a health protocol with optional steps",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "example": "New shelter cat" },
+                  "description": { "type": "string", "example": "Standard protocol for new cats" },
+                  "steps": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["eventTypeId", "dayOffset"],
+                      "properties": {
+                        "eventTypeId": { "type": "integer" },
+                        "dayOffset": { "type": "integer" },
+                        "product": { "type": "string" },
+                        "notes": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Protocol created with steps" }
+        }
+      }
+    },
+    "/api/protocols/{id}": {
+      "get": {
+        "tags": ["Protocols"],
+        "summary": "Get protocol detail with steps and assignments",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "200": { "description": "Protocol with steps and assignments" },
+          "404": { "description": "Protocol not found" }
+        }
+      },
+      "put": {
+        "tags": ["Protocols"],
+        "summary": "Update protocol (replaces steps if provided)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "200": { "description": "Protocol updated" },
+          "404": { "description": "Protocol not found" }
+        }
+      },
+      "delete": {
+        "tags": ["Protocols"],
+        "summary": "Delete protocol (blocks if has active assignments)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "responses": {
+          "204": { "description": "Protocol deleted" },
+          "400": { "description": "Has active assignments" },
+          "404": { "description": "Protocol not found" }
+        }
+      }
+    },
+    "/api/protocols/{id}/steps": {
+      "post": {
+        "tags": ["Protocol Steps"],
+        "summary": "Add a step to a protocol",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["eventTypeId", "dayOffset"],
+                "properties": {
+                  "eventTypeId": { "type": "integer" },
+                  "dayOffset": { "type": "integer", "example": 15 },
+                  "product": { "type": "string" },
+                  "notes": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Step added" }
+        }
+      }
+    },
+    "/api/protocols/{id}/steps/reorder": {
+      "put": {
+        "tags": ["Protocol Steps"],
+        "summary": "Reorder protocol steps",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["stepIds"],
+                "properties": {
+                  "stepIds": { "type": "array", "items": { "type": "integer" }, "example": [3, 1, 5, 2] }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Steps reordered" }
+        }
+      }
+    },
+    "/api/protocols/{protocolId}/steps/{stepId}": {
+      "put": {
+        "tags": ["Protocol Steps"],
+        "summary": "Update a protocol step",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "protocolId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "stepId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Step updated" },
+          "404": { "description": "Protocol or step not found" }
+        }
+      },
+      "delete": {
+        "tags": ["Protocol Steps"],
+        "summary": "Delete a step (auto-recompacts sortOrder)",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "protocolId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "stepId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "204": { "description": "Step deleted" },
+          "404": { "description": "Protocol or step not found" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Cuando se completa un evento de protocolo con retraso, recalcula en cascada las fechas de los eventos PENDING posteriores de la misma asignación
- Nuevo recalculation.service.js encapsula la lógica
- Eventos desplazados a fechas pasadas se marcan como OVERDUE
- PATCH /complete devuelve { recalculation: { delayDays, eventsUpdated } }
- Skip si: no protocolo, asignación cancelled, completado a tiempo/antes, sin eventos pendientes

## Test plan
- [ ] Completar evento de protocolo con retraso y verificar cascada
- [ ] Completar evento sin protocolo (no debe recalcular)
- [ ] Completar a tiempo (no debe recalcular)